### PR TITLE
Added 60dB integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@ To run this app on your local machine,
 1. **Prerequisites**: Before using Multivoice, users need to obtain the following:
 
    - **OpenAI API Token**: Users should sign up for the OpenAI API to enable translation services. API keys can be managed at [OpenAI API](https://platform.openai.com/account/api-keys).
-   - **ElevenLabs API Key**: Users must obtain an API key from ElevenLabs to access their Text-to-Speech (TTS) and voice cloning services. Sign up and API key management are available at [ElevenLabs](https://elevenlabs.io/sign-up).
+   - **A voice provider API key**: Multivoice supports two interchangeable backends for voice cloning and Text-to-Speech. Pick **one** in the sidebar and supply its key:
+     - **ElevenLabs** — sign up and manage keys at [ElevenLabs](https://elevenlabs.io/sign-up).
+     - **60db** — sign up and get an API key at [60db](https://60db.ai).
 
    Rest assured, the credentials provided by users are securely handled within the session state and are not permanently stored.
+
+   > **Choosing a provider:** A single provider drives the whole run (both cloning and TTS), because a cloned voice from one backend cannot be used by the other. Select it from the **Voice / TTS provider** dropdown in the sidebar before submitting your keys.
 
 2. **Web Application Usage**:
 
@@ -48,9 +52,13 @@ To run this app on your local machine,
 
 5. **Voice Cloning**:
 
-   - Multivoice leverages ElevenLabs' voice cloning technology to create personalized voice models for each user.
+   - Multivoice leverages the selected provider's voice cloning technology to create personalized voice models for each user.
 
-   - The extracted user audio files are sent to ElevenLabs to clone the corresponding user's voice. This step results in high-quality voice models that mimic the users' unique speech characteristics.
+   - The extracted user audio files are sent to the chosen backend to clone the corresponding user's voice, resulting in high-quality voice models that mimic each user's unique speech characteristics.
+
+   - **ElevenLabs**: cloning is instant — each user's audio is uploaded as a single file and a usable `voice_id` is returned immediately.
+
+   - **60db**: cloning is asynchronous and needs several short samples per character. Multivoice automatically splits each user's audio into 3–10 clips of 10–60 seconds, uploads them, and then polls until the voice finishes processing (this can take ~10–15 minutes per the provider). Characters with too little audio (roughly under 30s; 2 min is recommended) are skipped with a warning.
 
 6. **Translation**:
 
@@ -62,7 +70,7 @@ To run this app on your local machine,
 
    - Once the voice cloning and translation processes are complete, Multivoice combines the original audio with the dubbed dialogues for each user.
 
-   - The application replaces the original audio of the corresponding timestamps with the cloned user voice obtained from ElevenLabs. All other parts of the audio remain unaltered.
+   - The application replaces the original audio of the corresponding timestamps with the cloned user voice obtained from the selected provider. All other parts of the audio remain unaltered.
 
 8. **Enjoy the Multivoice Experience**:
 
@@ -72,6 +80,20 @@ To run this app on your local machine,
 Please note that the project includes sample data, including an MP3 audio file (`BigBangS01E03.mp3`), a `dialogues.json` file, and `subtitles.srt`, which are used for demonstrations.
 
 With Multivoice, immerse yourself in a world of diverse entertainment and enjoy foreign-language content like never before! 🌍🎉🎬😄
+
+## Voice Providers
+
+Multivoice supports two interchangeable cloning + Text-to-Speech backends, selected from the sidebar. They are implemented behind a common interface (`providers.py`), so the rest of the pipeline is provider-agnostic.
+
+| | ElevenLabs | 60db |
+|---|---|---|
+| Authentication | `xi-api-key` header | `Authorization: Bearer` header |
+| Cloning endpoint | `POST /v1/voices/add` | `POST /voices` |
+| Cloning input | 1 file, any length | 3–10 clips of 10–60s (auto-split); ≥2 min recommended |
+| Cloning result | Instant `voice_id` | Asynchronous — polled until ready (~10–15 min) |
+| TTS endpoint | `POST /v1/text-to-speech/{id}` → raw MP3 | `POST /tts-synthesize` → base64 audio (JSON) |
+
+To add another provider, implement the `TTSProvider` interface (`validate_token`, `clone_voice`, `synthesize`) in `providers.py` and register it in the `PROVIDERS` map.
 
 ## Disclaimer
 

--- a/constants.py
+++ b/constants.py
@@ -12,3 +12,17 @@ You can sign up for OpenAI API and manage your API usage by visiting [here](http
 EL_TOKEN = """
 To voice clone the characters and generate Text-to-Speech we need ElevenLabs API. You can sign up for ElevenLabs API and manage your API usage by visiting [here](https://elevenlabs.io/sign-up)
 """
+
+SIXTYDB_TOKEN = """
+60db is an alternative voice cloning + Text-to-Speech backend. Cloning on 60db is asynchronous (it needs several short samples per character and can take ~10-15 min). You can sign up and get an API key at [60db](https://60db.ai).
+"""
+
+PROVIDER_HELP = """
+Choose which backend clones the character voices and generates speech.\n
+A single provider is used for the whole run, because a cloned voice from one backend cannot be used by the other.
+"""
+
+PROVIDER_TOKEN_HELP = {
+    "ElevenLabs": EL_TOKEN,
+    "60db": SIXTYDB_TOKEN,
+}

--- a/credentials.py
+++ b/credentials.py
@@ -2,10 +2,19 @@ import streamlit as st
 import requests
 
 from constants import *
+from providers import PROVIDERS, build_provider
 
 def credentials():
     with st.sidebar:
         st.title("Authentication", help=AUTHENTICATION_HELP)
+
+        provider_name = st.selectbox(
+            "Voice / TTS provider",
+            list(PROVIDERS.keys()),
+            help=PROVIDER_HELP,
+        )
+        st.session_state["provider"] = provider_name
+
         with st.form("tokens"):
             openai_token = st.text_input(
                 "OpenAI API",
@@ -13,23 +22,23 @@ def credentials():
                 help=OPENAI_HELP,
                 placeholder="This field is mandatory"
             )
-            el_token = st.text_input(
-                "ElevenLabs Token",
+            provider_token = st.text_input(
+                f"{provider_name} API key",
                 type="password",
-                help=EL_TOKEN,
+                help=PROVIDER_TOKEN_HELP[provider_name],
                 placeholder="This field is mandatory"
             )
             submit_tokens = st.form_submit_button("Submit")
-    
+
     if submit_tokens:
         with st.spinner("Hang tight, validating the tokens..."):
-            if not(openai_token and el_token):
+            if not(openai_token and provider_token):
                 st.error("Enter all credentials")
                 st.stop()
-            if check_openai(openai_token) and check_el(el_token):
+            if check_openai(openai_token) and check_provider(provider_name, provider_token):
                 st.session_state["auth_ok"] = True
                 st.session_state["openai_token"] = openai_token
-                st.session_state["el_token"] = el_token
+                st.session_state["provider_token"] = provider_token
                 st.success("API Keys are valid")
 
 def check_openai(openai_token):
@@ -43,15 +52,9 @@ def check_openai(openai_token):
     st.error("Enter valid OpenAI token")
     st.stop()
 
-def check_el(el_token):
-    url = "https://api.elevenlabs.io/v1/models"
-    headers = {
-        "Accept": "application/json",
-        "xi-api-key": el_token
-    }
-    
-    response = requests.get(url, headers=headers)
-    if response.status_code == 200:
+def check_provider(provider_name, provider_token):
+    provider = build_provider(provider_name, provider_token)
+    if provider.validate_token(provider_token):
         return True
-    st.error("Enter valid ElevenLabs token")
+    st.error(f"Enter valid {provider_name} token")
     st.stop()

--- a/providers.py
+++ b/providers.py
@@ -1,0 +1,252 @@
+"""Voice/TTS provider abstraction.
+
+The dubbing pipeline (cloning + per-line synthesis) is written against the
+`TTSProvider` interface so the rest of the app never has to know which backend
+is in use. Two concrete providers are implemented:
+
+  * ElevenLabsProvider - instant single-file cloning, raw-MP3 TTS.
+  * SixtyDBProvider     - async multi-sample cloning (polled), base64-JSON TTS.
+
+A single provider drives BOTH cloning and synthesis for a run, because a
+voice_id minted by one backend cannot be used by the other.
+"""
+
+import io
+import time
+import base64
+
+import requests
+import streamlit as st
+
+from pydub import AudioSegment
+
+
+class TTSProvider:
+    """Common interface every backend implements."""
+
+    label = "provider"
+
+    def __init__(self, token):
+        self.token = token
+
+    def validate_token(self, token):
+        """Return True if the token is accepted by the backend."""
+        raise NotImplementedError
+
+    def clone_voice(self, name, audio):
+        """Clone a voice from a character's `AudioSegment`.
+
+        Returns a ready-to-use voice_id (str), or None if cloning could not be
+        completed (e.g. not enough source audio / backend failure).
+        """
+        raise NotImplementedError
+
+    def synthesize(self, voice_id, text):
+        """Synthesize one line of `text` in `voice_id`. Returns an
+        `AudioSegment`, or None on failure."""
+        raise NotImplementedError
+
+
+class ElevenLabsProvider(TTSProvider):
+    label = "ElevenLabs"
+    BASE = "https://api.elevenlabs.io/v1"
+
+    def validate_token(self, token):
+        response = requests.get(
+            f"{self.BASE}/models",
+            headers={"Accept": "application/json", "xi-api-key": token},
+        )
+        return response.status_code == 200
+
+    def clone_voice(self, name, audio):
+        buf = io.BytesIO()
+        audio.export(buf, format="mp3")
+        buf.seek(0)
+
+        headers = {"Accept": "application/json", "xi-api-key": self.token}
+        data = {
+            "name": name,
+            "labels": '{"accent": "American"}',
+            "description": f"Cloned from {name}",
+        }
+        files = [("files", (f"{name}.mp3", buf, "audio/mpeg"))]
+
+        response = requests.post(
+            f"{self.BASE}/voices/add", headers=headers, data=data, files=files
+        )
+        if not response.ok:
+            st.error(f"ElevenLabs cloning failed for '{name}': {response.text}")
+            return None
+        return response.json().get("voice_id")
+
+    def synthesize(self, voice_id, text):
+        headers = {
+            "Accept": "audio/mpeg",
+            "Content-Type": "application/json",
+            "xi-api-key": self.token,
+        }
+        data = {
+            "text": text,
+            "model_id": "eleven_multilingual_v1",
+            "voice_settings": {"stability": 0.5, "similarity_boost": 0.5},
+        }
+        response = requests.post(
+            f"{self.BASE}/text-to-speech/{voice_id}", json=data, headers=headers
+        )
+        if response.ok:
+            return AudioSegment.from_file(io.BytesIO(response.content))
+        return None
+
+
+class SixtyDBProvider(TTSProvider):
+    label = "60db"
+    BASE = "https://api.60db.ai"
+
+    # Cloning sample constraints (per 60db create-voice docs).
+    MIN_FILES = 3
+    MAX_FILES = 10
+    MIN_CHUNK_MS = 10_000
+    MAX_CHUNK_MS = 60_000
+    RECOMMENDED_TOTAL_MS = 120_000  # docs recommend >= 2 min combined
+
+    # Async cloning poll settings.
+    POLL_INTERVAL_S = 15
+    POLL_TIMEOUT_S = 1_200  # 20 min
+    PROCESSING_STATES = {"processing", "pending", "queued", "training", "in_progress"}
+    FAILED_STATES = {"failed", "error", "rejected"}
+
+    def _headers(self, json_body=False):
+        headers = {"Authorization": f"Bearer {self.token}"}
+        if json_body:
+            headers["Content-Type"] = "application/json"
+        return headers
+
+    def validate_token(self, token):
+        response = requests.get(
+            f"{self.BASE}/myvoices",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        return response.status_code == 200
+
+    def _split_chunks(self, audio):
+        """Split a character's audio into MIN_FILES..MAX_FILES clips of
+        MIN_CHUNK_MS..MAX_CHUNK_MS each. Returns None if there isn't enough
+        audio to satisfy the backend's minimum."""
+        total = len(audio)
+        if total < self.MIN_FILES * self.MIN_CHUNK_MS:
+            return None
+
+        # Aim for ~30s clips, clamped to the allowed file count and length.
+        n = max(self.MIN_FILES, min(self.MAX_FILES, total // 30_000))
+        step = max(self.MIN_CHUNK_MS, min(self.MAX_CHUNK_MS, total // n))
+
+        chunks = []
+        pos = 0
+        while pos + self.MIN_CHUNK_MS <= total and len(chunks) < self.MAX_FILES:
+            chunks.append(audio[pos:pos + step])
+            pos += step
+
+        if len(chunks) < self.MIN_FILES:
+            return None
+        return chunks
+
+    def clone_voice(self, name, audio):
+        chunks = self._split_chunks(audio)
+        if not chunks:
+            needed = (self.MIN_FILES * self.MIN_CHUNK_MS) // 1000
+            st.warning(
+                f"Not enough audio to clone '{name}' on 60db "
+                f"(need ~{needed}s+, ideally 2 min). Skipping this voice."
+            )
+            return None
+
+        if len(audio) < self.RECOMMENDED_TOTAL_MS:
+            st.info(
+                f"'{name}' has only {len(audio) // 1000}s of audio; 60db "
+                "recommends >= 2 min for best cloning quality."
+            )
+
+        files = []
+        for i, segment in enumerate(chunks):
+            buf = io.BytesIO()
+            segment.export(buf, format="mp3")
+            buf.seek(0)
+            files.append(("files", (f"{name}_{i}.mp3", buf, "audio/mpeg")))
+
+        data = {"name": name, "description": f"Cloned from {name}"}
+        response = requests.post(
+            f"{self.BASE}/voices", headers=self._headers(), data=data, files=files
+        )
+        if not response.ok:
+            st.error(f"60db cloning failed for '{name}': {response.text}")
+            return None
+
+        voice_id = response.json().get("id")
+        return self._wait_until_ready(voice_id, name)
+
+    def _wait_until_ready(self, voice_id, name):
+        """Poll Get-Voice until the async clone leaves a processing state."""
+        if not voice_id:
+            return None
+
+        waited = 0
+        while waited < self.POLL_TIMEOUT_S:
+            response = requests.get(
+                f"{self.BASE}/voices/{voice_id}", headers=self._headers()
+            )
+            if response.ok:
+                status = (response.json().get("status") or "").lower()
+                if status in self.FAILED_STATES:
+                    st.error(f"60db cloning failed for '{name}'.")
+                    return None
+                if status not in self.PROCESSING_STATES:
+                    return voice_id  # ready / no status field -> assume usable
+            time.sleep(self.POLL_INTERVAL_S)
+            waited += self.POLL_INTERVAL_S
+
+        st.warning(
+            f"Timed out waiting for 60db voice '{name}' to finish cloning; "
+            "using it anyway."
+        )
+        return voice_id
+
+    def synthesize(self, voice_id, text):
+        data = {
+            "text": text,
+            "voice_id": voice_id,
+            "speed": 1,
+            "stability": 50,
+            "similarity": 75,
+            "output_format": "mp3",
+        }
+        response = requests.post(
+            f"{self.BASE}/tts-synthesize", json=data, headers=self._headers(json_body=True)
+        )
+        if not response.ok:
+            return None
+
+        payload = response.json()
+        if not payload.get("success", True):
+            return None
+
+        audio_b64 = payload.get("audio_base64")
+        if not audio_b64:
+            return None
+        return AudioSegment.from_file(io.BytesIO(base64.b64decode(audio_b64)))
+
+
+PROVIDERS = {
+    ElevenLabsProvider.label: ElevenLabsProvider,
+    SixtyDBProvider.label: SixtyDBProvider,
+}
+
+
+def build_provider(name, token):
+    return PROVIDERS[name](token)
+
+
+def get_provider():
+    """Construct the active provider from session state."""
+    return build_provider(
+        st.session_state["provider"], st.session_state["provider_token"]
+    )

--- a/tts.py
+++ b/tts.py
@@ -1,31 +1,6 @@
-import io
-import requests
-import streamlit as st
+from providers import get_provider
 
-from pydub import AudioSegment
-
-CHUNK_SIZE = 1024
-
-def tts(id, text):
-    url = f"https://api.elevenlabs.io/v1/text-to-speech/{id}"
-
-    headers = {
-        "Accept": "audio/mpeg",
-        "Content-Type": "application/json",
-        "xi-api-key": st.session_state['el_token']
-    }
-
-    data = {
-        "text": text,
-        "model_id": "eleven_multilingual_v1",
-        "voice_settings": {
-            "stability": 0.5,
-            "similarity_boost": 0.5
-        }
-    }
-
-    response = requests.post(url, json=data, headers=headers)
-
-    if response.ok:
-        audio_content = io.BytesIO(response.content)
-        return AudioSegment.from_file(audio_content)
+def tts(voice_id, text):
+    """Synthesize one line of text in the given voice using the active
+    provider. Returns a pydub AudioSegment (or None on failure)."""
+    return get_provider().synthesize(voice_id, text)

--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,8 @@ def init_session_state():
     SESSION_DEFAULTS = {
         "auth_ok": False,
         "openai_token": False,
-        "el_token": None,
+        "provider": "ElevenLabs",
+        "provider_token": None,
         "json_file": None,
         "audio_file" :None,
         "voice_clone_dir": 'voice_clones',

--- a/voiceclone.py
+++ b/voiceclone.py
@@ -1,37 +1,28 @@
 import os
-import requests
 import streamlit as st
 
+from pydub import AudioSegment
+
+from providers import get_provider
+
 def clone():
+    provider = get_provider()
     audio_files = os.listdir('voice_clones/')
     st.session_state["voice_id"] = {}
     num_files = len(audio_files)
-        
+
     for f in audio_files:
         st.session_state["count"] += 1
         filepath = os.path.join('voice_clones/', f)
+        name = f.rsplit(".", 1)[0]
 
-        with st.spinner(f'Cloning {f.rsplit(".", 1)[0]} Voice'):
-            add_url = "https://api.elevenlabs.io/v1/voices/add"
-            headers = {
-                "Accept": "application/json",
-                "xi-api-key": st.session_state['el_token']
-            }
+        with st.spinner(f'Cloning {name} voice with {provider.label}'):
+            audio = AudioSegment.from_file(filepath)
+            voice_id = provider.clone_voice(name, audio)
 
-            data = {
-                'name': f,
-                'labels': '{"accent": "American"}',
-                'description': f'Cloned from {f}'
-            }
+            if voice_id:
+                st.session_state["voice_id"][name] = voice_id
 
-            files = [
-                ('files', (f, open(filepath, 'rb'), 'audio/mpeg'))
-            ]
-
-            response = requests.post(add_url, headers=headers, data=data, files=files)
-            cloned_voice_id = response.json()['voice_id']
-        
-            st.session_state["voice_id"][f.rsplit(".", 1)[0]] = cloned_voice_id
     if st.session_state["count"] == num_files != 0:
         st.session_state["clone"] = True
         st.session_state["auth_ok"] = False


### PR DESCRIPTION
 Added 60db as a second voice/TTS provider alongside ElevenLabs, behind a common TTSProvider interface (providers.py) so the       
  pipeline works the same regardless of backend.

  - providers.py (new) — ElevenLabsProvider + SixtyDBProvider (auth, cloning, TTS). 60db auto-splits audio into 3–10 clips and polls
  its async clone until ready; decodes base64 TTS audio.
  - credentials.py — sidebar provider dropdown + provider-specific key validation.
  - tts.py / voiceclone.py — now delegate to the selected provider.
  - utils.py / constants.py — provider + provider_token state and help text.
  - README.md — provider comparison + updated steps.

  How to use it

  1. streamlit run app.py
  2. Sidebar → pick ElevenLabs or 60db from the Voice / TTS provider dropdown.
  3. Enter your OpenAI key + the chosen provider's key, then Submit.
  4. Upload dialogues JSON + source MP3 → it clones each character's voice (ElevenLabs = instant; 60db = ~10–15 min async polling). 
  5. Select a language → Submit → it translates, re-synthesizes in the cloned voices, and plays the dubbed output.mp3.